### PR TITLE
docs: add missing pytest installation step to contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -221,6 +221,11 @@ venv\Scripts\activate      # Windows
 
 ```bash
 pip install -r requirements.txt
+
+(Note: The testing framework is not included in the main requirements file to keep production dependencies light. If you plan on running tests, please install it manually:)
+
+
+pip install pytest
 ```
 
 ---


### PR DESCRIPTION
What I did: Added instructions to manually install pytest.

Why it’s needed: It was missing from the requirements.txt file, causing the test command to fail for new contributors.